### PR TITLE
feat: Dockerize project with docker-compose

### DIFF
--- a/FinanceTrackingAPI/Dockerfile
+++ b/FinanceTrackingAPI/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.8-slim as base
+
+FROM base as dependencies
+RUN pip install pipenv
+RUN apt-get update && apt-get install -y --no-install-recommends gcc
+
+COPY Pipfile .
+COPY Pipfile.lock .
+# env var here ensures build output is stored in /.venv instead of a temp directory
+RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy
+
+
+FROM base as runtime
+
+# Copy venv source from 'dependencies' stage
+COPY --from=dependencies /.venv /.venv
+ENV PATH="/.venv/bin:$PATH"
+WORKDIR /home/appuser
+
+COPY . .
+
+EXPOSE 5000
+ENTRYPOINT [ "python" ]
+CMD [ "-m", "src.main" ]

--- a/FinanceTrackingAPI/src/entities/entity.py
+++ b/FinanceTrackingAPI/src/entities/entity.py
@@ -2,12 +2,14 @@ from datetime import datetime
 from sqlalchemy import create_engine, Column, String, Integer, DateTime
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from os import getenv
 
-db_url = '192.168.99.100:3306'
+db_host = getenv('DB_HOST', '192.168.99.100')
+db_port = getenv('DB_PORT', '3306')
 db_name = 'FinanceTracking'
 db_user = 'root'
 db_password = 'Test123'
-engine = create_engine(f'mysql+pymysql://{db_user}:{db_password}@{db_url}/{db_name}')
+engine = create_engine(f'mysql+pymysql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}')
 Session = sessionmaker(bind=engine)
 
 Base = declarative_base()

--- a/FinanceTrackingAPI/src/main.py
+++ b/FinanceTrackingAPI/src/main.py
@@ -50,4 +50,4 @@ def add_test():
     return jsonify(new_test), 201
 
 if __name__ == "__main__":
-    app.run()
+    app.run(host='0.0.0.0')

--- a/FinanceTrackingUI/.dockerignore
+++ b/FinanceTrackingUI/.dockerignore
@@ -1,0 +1,3 @@
+/node_modules
+/dist
+/.git

--- a/FinanceTrackingUI/Dockerfile
+++ b/FinanceTrackingUI/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:12.18-stretch-slim as base
+
+WORKDIR /home/app
+
+COPY package.json package-lock.json ./
+
+RUN npm install
+
+COPY . /home/app
+
+EXPOSE 4200
+CMD [ "npm", "start", "--", "--host", "0.0.0.0" ]

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -2,7 +2,7 @@
 
 ## Description
 The goal of this project is to provide users an insight into how much they're spending over a period of time along with the distribution of money that is spent on particular things (Shopping, Car Expenses, Misc., etc.) along with tracking how much money they're having come in each month.
-This information should be determined given a CSV file formatted to match the expected formatting. Most banks allow you to export a CSV report which is why I went with this. 
+This information should be determined given a CSV file formatted to match the expected formatting. Most banks allow you to export a CSV report which is why I went with this.
 
 ## Getting Started
 
@@ -30,6 +30,25 @@ This information should be determined given a CSV file formatted to match the ex
 1) Move into the FinanceTrackingUI directory
 2) I personally like to run ```npm install``` to ensure I have all the packages needed for the angular project.
 3) After that run ```npm start``` or ```ng serve``` to start running the Angular application locally, refer to the [README.md](FinanceTrackingUI/README.md) in the FinanceTrackingUI directory for additional information and commands related to running the Angular application.
+
+## Spin up all instances with `docker-compose`
+```shell
+# when in the project root
+$ docker-compose up -d
+
+# images + containers will be built
+
+# clean up containers afterwards
+$ docker-compose down -v
+```
+
+While container instances are live, you can inspect the dashboard (and backend) at these ports:
+
+|         |    Link   |
+| ------- | --------- |
+|    UI   | http://localhost:4200/ |
+| Backend | http://localhost:5000/ |
+
 
 ## Future Enhancements
 **This is still a work in progress.**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3"
+
+services:
+  mysql:
+    image: mysql:5.7
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: Test123
+      MYSQL_DATABASE: FinanceTracking
+    restart: always
+
+  api:
+    build:
+      context: ./FinanceTrackingAPI
+    depends_on:
+      - mysql
+    ports:
+      - 5000:5000
+    links:
+      - mysql
+    environment:
+      DB_HOST: mysql
+      DB_PORT: 3306
+
+  ui:
+    build:
+      context: ./FinanceTrackingUI
+    depends_on:
+      - api
+    ports:
+      - 4200:4200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,5 @@ services:
   ui:
     build:
       context: ./FinanceTrackingUI
-    depends_on:
-      - api
     ports:
       - 4200:4200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,19 @@ services:
       MYSQL_ROOT_PASSWORD: Test123
       MYSQL_DATABASE: FinanceTracking
     restart: always
+    healthcheck:
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      timeout: 60s
+      interval: 10s
+      retries: 5
+
 
   api:
     build:
       context: ./FinanceTrackingAPI
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
     ports:
       - 5000:5000
     links:


### PR DESCRIPTION
Resolves #8 

This PR adds:
* Dockerfiles for the UI + API projects
* `docker-compose.yml`
* mysql config for the compose script
* small adjustments to the mysql initialization, to read down from env vars for the host + port
* README instructions

Caveats:
* the UI project takes a good chunk of time to compile so I opted to use the development server - I figured the dockerization was mainly for testing at the moment so I left out production compile flags etc.  Also, rather than pull in an nginx image, I'm having the UI's container simply `npm start` via `ng`.  
* the mysql container will have a 10s health check -- this is to resolve some startup race condition where the api container comes up before the mysql server has a chance to fully initialize


Proof of running containers:
* client runs on port 4200
* api runs on port 5000
![image](https://user-images.githubusercontent.com/19556538/95667924-9f566e00-0b21-11eb-8259-4eb067608460.png)
